### PR TITLE
Fix incorrect indentation in dinghy docker compose file

### DIFF
--- a/docker-compose-dinghy.yml
+++ b/docker-compose-dinghy.yml
@@ -36,7 +36,7 @@ services:
     network_mode: bridge
 
   nginx:
-      image: dockerwest/nginx-symfony${SYMFONYVERSION:-4}:${NGINXVERSION:-stable}
+    image: dockerwest/nginx-symfony${SYMFONYVERSION:-4}:${NGINXVERSION:-stable}
     environment:
       - VIRTUAL_HOST=${BASEHOST:-application.docker},${EXTRAHOSTS}
       - VIRTUAL_PORT=80


### PR DESCRIPTION
There is some incorrect indentation in the dinghy docker compose file which makes the yaml invalid and impossible to start the containers.