### PR TITLE
Make environment file compatible with Dash shell (default shell on Ubuntu)

### DIFF
--- a/environment
+++ b/environment
@@ -14,7 +14,7 @@ init_environment() {
 }
 
 uname=$(uname)
-if [[ "$uname" == "Linux" ]]; then
+if [ "$uname" = "Linux" ]; then
     cd "$(dirname "$(readlink -f "$0")")"
 else
     cd "$(cd "$(dirname "$0")"; pwd -P)"


### PR DESCRIPTION
The environment file works nicely when using bash, but when I use the dash shell (which is my `/bin/sh` by default on my Ubuntu 18.04) I got the following error:
`./environment: 17: ./environment: [[: not found`

So, this merge request fixes that issue and still works properly with bash.